### PR TITLE
Add csrf origin for codespaces

### DIFF
--- a/hello_world/settings.py
+++ b/hello_world/settings.py
@@ -9,7 +9,7 @@ https://docs.djangoproject.com/en/4.1/topics/settings/
 For the full list of settings and their values, see
 https://docs.djangoproject.com/en/4.1/ref/settings/
 """
-
+import os
 from pathlib import Path
 
 # Build paths inside the project like this: BASE_DIR / 'subdir'.
@@ -27,6 +27,10 @@ DEBUG = True
 
 ALLOWED_HOSTS = []
 
+if 'CODESPACE_NAME' in os.environ:
+    codespace_name = os.getenv("CODESPACE_NAME")
+    codespace_domain = os.getenv("GITHUB_CODESPACES_PORT_FORWARDING_DOMAIN")
+    CSRF_TRUSTED_ORIGINS = [f'https://{codespace_name}-8000.{codespace_domain}']
 
 # Application definition
 


### PR DESCRIPTION
## Purpose

Currently, due to the way Codespace "local" URLs work, it's not possible to log in to the Django admin panel. A CSRF error displays instead.

This PR overrides CSRF_TRUSTED_ORIGINS when the app is using the development settings and when an environment variable is present that indicates its running in Codespaces. 

## How to Test

Both in Codespaces and locally:

* python manage.py createsuperuser
* python manage.py runserver
* Try logging into /admin with your superuser credentials. It won't work in the embedded browser since that seems to disable cookies. However, it should work if you pop it out.
