### PR TITLE
Fix invalid devcontainer.json

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,4 +1,5 @@
 {
+  "image": "mcr.microsoft.com/devcontainers/universal:2",
   "hostRequirements": {
     "cpus": 4
   },


### PR DESCRIPTION
A number of these templates are missing an image reference, which means they won't work anywhere outside of Codespaces, including in the Dev Container GitHub Action.

If the goal is to use the "kitchen sink" image, all that is needed is a reference to the image. This will be slow in other scenarios, but won't fail like it would today.