### PR TITLE
Mark `*.html` files as HTML+Django for GitHub Linguist

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.html linguist-language=HTML+Django


### PR DESCRIPTION
This will apply more accurate syntax highlighting (filters and tags will be highlighted). Because Django templates are considered to be the same as Jinja templates in Linguist, the detected language is changed from HTML to Jinja.